### PR TITLE
Saving settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "set TAILWIND_MODE=watch && vue-cli-service serve",
+    "serve": "vue-cli-service serve",
+    "serve:mac": "TAILWIND_MODE=watch vue-cli-service serve",
     "build": "vue-cli-service build",
     "jest": "vue-cli-service test:unit"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "TAILWIND_MODE=watch vue-cli-service serve",
+    "serve": "set TAILWIND_MODE=watch && vue-cli-service serve",
     "build": "vue-cli-service build",
     "jest": "vue-cli-service test:unit"
   },

--- a/package.json
+++ b/package.json
@@ -8,14 +8,16 @@
     "jest": "vue-cli-service test:unit"
   },
   "dependencies": {
+    "@sweetalert2/theme-bulma": "^5.0.1",
+    "autoprefixer": "^9",
     "core-js": "^3.6.5",
     "cuid": "^2.1.8",
     "localforage": "^1.9.0",
+    "postcss": "7",
     "v-click-outside": "^3.1.2",
     "vue": "^2.6.11",
-    "vuex": "^3.4.0",
-    "autoprefixer": "^9",
-    "postcss": "7"
+    "vue-sweetalert2": "^5.0.2",
+    "vuex": "^3.4.0"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "~4.5.0",

--- a/public/index.html
+++ b/public/index.html
@@ -1,15 +1,18 @@
 <!DOCTYPE html>
 <html lang="">
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <link rel="icon" href="<%= BASE_URL %>favicon.ico">
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <link rel="icon" href="<%= BASE_URL %>favicon.ico" />
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
   <body style="overscroll-behavior: contain;">
     <noscript>
-      <strong>We're sorry but <%= htmlWebpackPlugin.options.title %> doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+      <strong>
+        We're sorry but <%= htmlWebpackPlugin.options.title %> doesn't work properly
+        without JavaScript enabled. Please enable it to continue.
+      </strong>
     </noscript>
     <div id="app"></div>
     <!-- built files will be auto injected -->

--- a/src/App.vue
+++ b/src/App.vue
@@ -104,7 +104,7 @@ export default {
   data() {
     return {
       mousePosition: { x: 0, y: 0 },
-      settingsAreOpen: true,
+      settingsAreOpen: false,
     }
   },
   methods: {

--- a/src/App.vue
+++ b/src/App.vue
@@ -148,7 +148,7 @@ export default {
         }
       }
 
-      if (e.keyCode == 93 && this.$store.state.keysPressed.length == 0) {
+      if (e.keyCode == 17 && this.$store.state.keysPressed.length == 0) {
         document.getElementById('board-container').style.cursor = 'pointer'
         this.$store.commit('keydown', e.keyCode)
       }

--- a/src/App.vue
+++ b/src/App.vue
@@ -104,7 +104,7 @@ export default {
   data() {
     return {
       mousePosition: { x: 0, y: 0 },
-      settingsAreOpen: false,
+      settingsAreOpen: true,
     }
   },
   methods: {

--- a/src/assets/tailwind.css
+++ b/src/assets/tailwind.css
@@ -50,3 +50,10 @@ body {
   border: 1px solid #197c4acc;
   border-right: 2px solid #197c4acc;
 }
+
+.swal2-container {
+  z-index: 1200;
+}
+.swal2-confirm {
+  background-color: #197c4a !important;
+}

--- a/src/assets/tailwind.css
+++ b/src/assets/tailwind.css
@@ -24,6 +24,9 @@ button {
 .btn.rounded-full {
   border-radius: 9999px;
 }
+.btn.highlighted {
+  @apply bg-gray-100 bg-opacity-10 !important;
+}
 
 body {
   @apply font-sans antialiased;

--- a/src/assets/tailwind.css
+++ b/src/assets/tailwind.css
@@ -15,6 +15,15 @@ button {
   padding-top: 0.125rem;
   padding-bottom: 0.175rem;
 }
+.btn {
+  @apply h-8 px-3 border rounded text-sm tracking-wide bg-black bg-opacity-10 border-gray-100 text-gray-100;
+}
+.btn-active {
+  @apply border-green-500 text-green-200 !important;
+}
+.btn.rounded-full {
+  border-radius: 9999px;
+}
 
 body {
   @apply font-sans antialiased;

--- a/src/components/HexGrid/HexGridController.vue
+++ b/src/components/HexGrid/HexGridController.vue
@@ -41,7 +41,7 @@ export default {
           resources.push({
             name,
             amount,
-            backgroundColor: this.$store.getters.resourceColors.main[name],
+            backgroundColor: this.$store.state.board.colors.resources.main[name],
           })
         }
       }
@@ -154,6 +154,12 @@ export default {
 
       this.$store.commit('setBoardState', newBoardState)
     },
+    buildNewBoard() {
+      this.addTileRows()
+
+      this.$store.dispatch('setBoardColors')
+      this.$store.dispatch('setBoardLandscapes')
+    },
   },
   watch: {
     rowCount(newValue, oldValue) {
@@ -178,16 +184,18 @@ export default {
   async created() {
     await this.setApplicationState()
 
-    const stashedRowsCount = this.tileRows.length
-    this.addTileRows(this.rowCount, stashedRowsCount)
+    if (this.tileRows.length == 0) {
+      this.buildNewBoard()
+    }
 
-    EventBus.$on('buildGrid', this.addTileRows)
+    EventBus.$on('buildNewBoard', this.buildNewBoard)
     EventBus.$on('reassignResources', this.reassignResources)
 
     this.$store.commit('initialised')
   },
   destroyed() {
-    EventBus.$off('buildGrid', this.addTileRows)
+    EventBus.$off('buildNewBoard', this.buildNewBoard)
+    EventBus.$off('reassignResources', this.reassignResources)
   },
 }
 </script>

--- a/src/components/HexGrid/HexGridController.vue
+++ b/src/components/HexGrid/HexGridController.vue
@@ -41,7 +41,7 @@ export default {
           resources.push({
             name,
             amount,
-            backgroundColor: this.$store.getters.resourceColors[name],
+            backgroundColor: this.$store.getters.resourceColors.main[name],
           })
         }
       }
@@ -70,20 +70,17 @@ export default {
           const stashedTile = stashedRow ? stashedRow[newRow.length] : null
           let landscapeType
           let resources
-          let color
           let id
 
           if (!stashedTile) {
             landscapeType = this.getLandscapeType()
             resources = this.getResources(landscapeType)
-            color = this.$store.getters.landscapeColors[landscapeType]
             id = cuid()
           }
 
           tile = stashedTile || {
             landscapeType,
             resources,
-            color,
             id,
           }
         }

--- a/src/components/HexGrid/HexGridController.vue
+++ b/src/components/HexGrid/HexGridController.vue
@@ -24,7 +24,7 @@ export default {
   methods: {
     ...mapActions([
       'getRowFromStash',
-      'setInitialState',
+      'setApplicationState',
       'storeTileRow',
       'storeModifiedTileRow',
     ]),
@@ -179,7 +179,7 @@ export default {
     },
   },
   async created() {
-    await this.setInitialState()
+    await this.setApplicationState()
 
     const stashedRowsCount = this.tileRows.length
     this.addTileRows(this.rowCount, stashedRowsCount)

--- a/src/components/HexGrid/HexGridTile.vue
+++ b/src/components/HexGrid/HexGridTile.vue
@@ -25,8 +25,8 @@
               :key="resource.name"
               class="resourceItem"
               :style="{
-                backgroundColor: resource.backgroundColor,
-                color: getInvertedHexcolorGrayscale(resource.backgroundColor),
+                backgroundColor: $store.getters.landscapeColors.main[resource.name],
+                color: $store.getters.landscapeColors.grayscale[resource.name],
               }"
             >
               <WoodIcon v-if="resource.name == 'wood' && tileIsLargeEnough" />
@@ -94,7 +94,7 @@ export default {
       return {
         display: 'flex',
         gap: `${1 / 50}vw`,
-        backgroundColor: this.tile.color,
+        backgroundColor: this.$store.getters.landscapeColors.main[this.tile.landscapeType],
         fontSize: `clamp(8px, ${1 / 10}vw, 20px`,
         height: `${100 - this.borderWidth}%`,
         width: `${100 - this.borderWidth}%`,

--- a/src/components/HexGrid/HexGridTile.vue
+++ b/src/components/HexGrid/HexGridTile.vue
@@ -25,8 +25,8 @@
               :key="resource.name"
               class="resourceItem"
               :style="{
-                backgroundColor: $store.getters.landscapeColors.main[resource.name],
-                color: $store.getters.landscapeColors.grayscale[resource.name],
+                backgroundColor: $store.getters.resourceColors.main[resource.name],
+                color: $store.getters.resourceColors.grayscale[resource.name],
               }"
             >
               <WoodIcon v-if="resource.name == 'wood' && tileIsLargeEnough" />
@@ -109,7 +109,7 @@ export default {
     resources() {
       return [...this.tile.resources]
         .filter(r => r.amount > 0)
-        .sort((a, b) => a.amount - b.amount)
+        .sort((a, b) => b.amount - a.amount)
     },
   },
   methods: {

--- a/src/components/HexGrid/HexGridTile.vue
+++ b/src/components/HexGrid/HexGridTile.vue
@@ -10,7 +10,15 @@
       :style="`margin: -${borderWidth}`"
     >
       <div class="hex-grid-item__content" :style="{ ...tileContentStyle }">
-        <span :style="`margin-top: ${size / 5}px;`">{{ tile.number }}</span>
+        <span
+          :style="
+            `margin-top: ${size / 5}px; color: ${
+              $store.state.board.colors.landscapes.grayscale[tile.landscapeType]
+            }77`
+          "
+        >
+          {{ tile.number }}
+        </span>
         <transition name="fade" mode="out-in">
           <div
             v-show="$store.state.preferences.showResourceValues"
@@ -94,7 +102,9 @@ export default {
       return {
         display: 'flex',
         gap: `${1 / 50}vw`,
-        backgroundColor: this.$store.state.board.colors.landscapes.main[this.tile.landscapeType],
+        backgroundColor: this.$store.state.board.colors.landscapes.main[
+          this.tile.landscapeType
+        ],
         fontSize: `clamp(8px, ${1 / 10}vw, 20px`,
         height: `${100 - this.borderWidth}%`,
         width: `${100 - this.borderWidth}%`,
@@ -183,7 +193,6 @@ svg {
 .hex-grid-item__content {
   align-items: center;
   clip-path: polygon(75% 0, 100% 50%, 75% 100%, 25% 100%, 0 50%, 25% 0);
-  color: rgba(255, 255, 255, 0.6);
   display: flex;
   flex-direction: column;
   font-size: 0.7vw;

--- a/src/components/HexGrid/HexGridTile.vue
+++ b/src/components/HexGrid/HexGridTile.vue
@@ -25,8 +25,8 @@
               :key="resource.name"
               class="resourceItem"
               :style="{
-                backgroundColor: $store.getters.resourceColors.main[resource.name],
-                color: $store.getters.resourceColors.grayscale[resource.name],
+                backgroundColor: $store.state.board.colors.resources.main[resource.name],
+                color: $store.state.board.colors.resources.grayscale[resource.name],
               }"
             >
               <WoodIcon v-if="resource.name == 'wood' && tileIsLargeEnough" />
@@ -94,7 +94,7 @@ export default {
       return {
         display: 'flex',
         gap: `${1 / 50}vw`,
-        backgroundColor: this.$store.getters.landscapeColors.main[this.tile.landscapeType],
+        backgroundColor: this.$store.state.board.colors.landscapes.main[this.tile.landscapeType],
         fontSize: `clamp(8px, ${1 / 10}vw, 20px`,
         height: `${100 - this.borderWidth}%`,
         width: `${100 - this.borderWidth}%`,
@@ -115,7 +115,7 @@ export default {
   methods: {
     getInvertedHexcolorGrayscale,
     toggleTileSelection(tile) {
-      if (!this.$store.state.keysPressed.includes(93)) return
+      if (!this.$store.state.keysPressed.includes(17)) return
 
       const foundIndex = this.$store.state.board.selectedTiles.indexOf(tile.id)
 

--- a/src/components/LandscapeOverview.vue
+++ b/src/components/LandscapeOverview.vue
@@ -35,7 +35,7 @@
               <p class="font-bold truncate mr-1">
                 {{ landscape.name }}
               </p>
-              <span v-if="isExpanded(landscape.name)">
+              <span v-if="isExpanded(landscape.name)" class="whitespace-nowrap">
                 <span
                   class="text-sm font-mono px-[3px]"
                   v-text="
@@ -97,6 +97,9 @@ export default {
     },
     landscapes() {
       return this.$store.state.board.landscapesAndResources
+    },
+    tileRows() {
+      return this.$store.state.board.tileRows
     },
   },
   methods: {

--- a/src/components/LandscapeOverview.vue
+++ b/src/components/LandscapeOverview.vue
@@ -63,8 +63,8 @@
               class="rounded px-2 flex justify-between font-mono space-x-6"
               :class="isExpanded(landscape.name) && 'w-full'"
               :style="{
-                backgroundColor: $store.getters.resourceColors[resource.name],
-                color: $store.getters.invertedResourceColors[resource.name],
+                backgroundColor: $store.getters.resourceColors.main[resource.name],
+                color: $store.getters.resourceColors.inverted[resource.name],
               }"
             >
               <p v-if="isExpanded(landscape.name)" class="font-semibold truncate">

--- a/src/components/LandscapeOverview.vue
+++ b/src/components/LandscapeOverview.vue
@@ -22,8 +22,8 @@
               index !== 0 && 'mt-2',
             ]"
             :style="{
-              backgroundColor: landscape.color,
-              color: landscape.invertedColor,
+              backgroundColor: colors.landscapes.main[landscape.name],
+              color: colors.landscapes.inverted[landscape.name],
               direction: 'ltr',
             }"
             @click="toggleExpanded(landscape.name)"
@@ -39,9 +39,8 @@
                 <span
                   class="text-sm font-mono px-[3px]"
                   v-text="
-                    $store.state.board.tileRows
-                      .flat()
-                      .filter(tile => tile.landscapeType == landscape.name).length
+                    tileRows.flat().filter(tile => tile.landscapeType == landscape.name)
+                      .length
                   "
                 />
                 <svg
@@ -63,8 +62,8 @@
               class="rounded px-2 flex justify-between font-mono space-x-6"
               :class="isExpanded(landscape.name) && 'w-full'"
               :style="{
-                backgroundColor: $store.getters.resourceColors.main[resource.name],
-                color: $store.getters.resourceColors.inverted[resource.name],
+                backgroundColor: colors.resources.main[resource.name],
+                color: colors.resources.inverted[resource.name],
               }"
             >
               <p v-if="isExpanded(landscape.name)" class="font-semibold truncate">
@@ -93,8 +92,11 @@ export default {
     }
   },
   computed: {
+    colors() {
+      return this.$store.state.board.colors
+    },
     landscapes() {
-      return this.$store.state.landscapes.data
+      return this.$store.state.board.landscapesAndResources
     },
   },
   methods: {

--- a/src/components/LandscapeSummary.vue
+++ b/src/components/LandscapeSummary.vue
@@ -7,8 +7,8 @@
       v-for="(value, name) in totalResources"
       :key="name"
       :style="{
-        backgroundColor: $store.getters.resourceColors.main[name],
-        color: $store.getters.resourceColors.inverted[name],
+        backgroundColor: $store.state.board.colors.resources.main[name],
+        color: $store.state.board.colors.resources.inverted[name],
       }"
     >
       {{ name }}:

--- a/src/components/LandscapeSummary.vue
+++ b/src/components/LandscapeSummary.vue
@@ -7,8 +7,8 @@
       v-for="(value, name) in totalResources"
       :key="name"
       :style="{
-        backgroundColor: $store.getters.resourceColors[name],
-        color: $store.getters.invertedResourceColors[name],
+        backgroundColor: $store.getters.resourceColors.main[name],
+        color: $store.getters.resourceColors.inverted[name],
       }"
     >
       {{ name }}:

--- a/src/components/SettingsWindow/AdjustBoard.vue
+++ b/src/components/SettingsWindow/AdjustBoard.vue
@@ -119,9 +119,14 @@ export default {
   },
   computed: {
     currentDataSet() {
-      return Object.entries(
-        this.$store.state.board.colors[this.activeTab].main
-      ).map(([key, value]) => ({ name: key, color: value }))
+      const currentDataSet = this.$store.state.board.colors[this.activeTab]?.main
+
+      return currentDataSet
+        ? Object.entries(currentDataSet).map(([key, value]) => ({
+            name: key,
+            color: value,
+          }))
+        : []
     },
   },
   methods: {

--- a/src/components/SettingsWindow/AdjustBoard.vue
+++ b/src/components/SettingsWindow/AdjustBoard.vue
@@ -13,18 +13,9 @@
         <button class="btn rounded-full w-full" @click="resetAdjustments">
           Återställ
         </button>
-        <button
-          class="btn w-full !mt-auto"
-          :class="$store.state.preferences.showResourceValues && 'btn-active'"
-          @click="toggleResourceValuesVisibility"
-        >
-          {{ $store.state.preferences.showResourceValues ? 'Visar' : 'Visa' }}
-          resursvärden
-        </button>
       </div>
     </div>
     <div class="flex flex-col items-center space-y-6 flex-1 min-h-0">
-      <p class="text-[#9f9f9f]">Färger på nuvarande bräde</p>
       <div class="h-8 w-full flex items-center px-[1.25rem]">
         <div class="flex w-full rounded overflow-hidden">
           <button
@@ -58,6 +49,8 @@
           :key="item.name"
           :item="item"
           :tab="activeTab"
+          parentTab="adjustBoard"
+          @change="submitChange"
         />
       </div>
     </div>
@@ -70,7 +63,7 @@ import LandscapeOrResourceItem from './LandscapeOrResourceItem'
 import { scrollToCenter } from '@/helpers/scroll.js'
 
 export default {
-  name: 'BoardAndTiles',
+  name: 'AdjustBoard',
   components: {
     GridSettingsItem,
     LandscapeOrResourceItem,
@@ -126,14 +119,12 @@ export default {
   },
   computed: {
     currentDataSet() {
-      return this.$store.state[this.activeTab].data
+      return Object.entries(
+        this.$store.state.board.colors[this.activeTab].main
+      ).map(([key, value]) => ({ name: key, color: value }))
     },
   },
   methods: {
-    toggleResourceValuesVisibility(e) {
-      this.$store.commit('toggleVisibility', 'ResourceValues')
-      e.currentTarget.blur()
-    },
     resetAdjustments() {
       this.$store.dispatch('resetAdjustments')
       scrollToCenter()
@@ -141,6 +132,13 @@ export default {
     switchTab(e, tabName) {
       this.activeTab = tabName
       e.currentTarget.blur()
+    },
+    submitChange(item, property, value) {
+      this.$store.commit('setBoardColor', {
+        dataset: this.activeTab,
+        itemName: item.name,
+        color: value,
+      })
     },
   },
 }

--- a/src/components/SettingsWindow/BoardAndTiles.vue
+++ b/src/components/SettingsWindow/BoardAndTiles.vue
@@ -29,7 +29,6 @@
 </template>
 
 <script>
-import EventBus from '@/eventBus'
 import GridSettingsItem from './GridSettingsItem'
 import { scrollToCenter } from '@/helpers/scroll.js'
 

--- a/src/components/SettingsWindow/BoardAndTiles.vue
+++ b/src/components/SettingsWindow/BoardAndTiles.vue
@@ -1,47 +1,29 @@
 <template>
   <div class="flex w-full h-full">
     <div class="flex-1">
-      <div class="mx-auto w-[min-content] flex flex-col space-y-3">
+      <div class="mx-auto w-[11rem] flex flex-col space-y-3 h-full">
         <button
-          class="h-8 w-full border rounded  text-sm tracking-wide bg-black mb-6"
-          :class="
-            $store.state.preferences.showResourceValues
-              ? '!border-green-500 text-green-200'
-              : 'border-gray-300 text-gray-300 !bg-opacity-10'
-          "
+          class="btn w-full !mt-auto"
+          :class="$store.state.preferences.showResourceValues && 'btn-active'"
           @click="toggleResourceValuesVisibility"
         >
           {{ $store.state.preferences.showResourceValues ? 'Visar' : 'Visa' }}
           resursvärden
         </button>
-
-        <button
-          class="h-8 w-full px-3 border rounded-full  text-sm tracking-wide bg-black border-gray-100 text-gray-100"
-          @click="generateNewResourceValues"
-        >
-          Generera nya resursvärden
-        </button>
-        <button
-          class="h-8 w-full px-3 border rounded-full  text-sm tracking-wide bg-black border-gray-100 text-gray-100"
-          @click="generateNewTiles"
-        >
-          Generera nytt bräde
-        </button>
       </div>
     </div>
-    <div class="text-white flex flex-col h-full justify-between flex-1">
-      <GridSettingsItem
-        class="w-48 mx-auto"
-        v-for="property in gridProperties"
-        :key="property.name"
-        :property="property"
-      />
-      <button
-        class="h-8 w-36 mx-auto border rounded-full  text-sm tracking-wide bg-black border-gray-100 text-gray-100"
-        @click="resetAdjustments"
-      >
-        Återställ justeringar
-      </button>
+    <div class="flex-1 h-full">
+      <div class="text-white flex flex-col h-full w-[11rem] justify-between mx-auto">
+        <GridSettingsItem
+          class="w-full mx-auto"
+          v-for="property in gridProperties"
+          :key="property.name"
+          :property="property"
+        />
+        <button class="btn rounded-full w-full" @click="resetAdjustments">
+          Återställ
+        </button>
+      </div>
     </div>
   </div>
 </template>
@@ -111,14 +93,6 @@ export default {
     },
     resetAdjustments() {
       this.$store.dispatch('resetAdjustments')
-      scrollToCenter()
-    },
-    generateNewResourceValues() {
-      EventBus.$emit('reassignResources')
-      this.$emit('close')
-    },
-    generateNewTiles() {
-      this.$store.dispatch('generateNewTiles')
       scrollToCenter()
     },
   },

--- a/src/components/SettingsWindow/BoardAndTiles.vue
+++ b/src/components/SettingsWindow/BoardAndTiles.vue
@@ -1,7 +1,18 @@
 <template>
   <div class="flex w-full h-full">
     <div class="flex-1">
-      <div class="mx-auto w-[11rem] flex flex-col space-y-3 h-full">
+      <div
+        class="mx-auto w-[11rem] flex flex-col space-y-6 h-full text-white justify-between"
+      >
+        <GridSettingsItem
+          class="w-full mx-auto"
+          v-for="property in gridProperties"
+          :key="property.name"
+          :property="property"
+        />
+        <button class="btn rounded-full w-full" @click="resetAdjustments">
+          Återställ
+        </button>
         <button
           class="btn w-full !mt-auto"
           :class="$store.state.preferences.showResourceValues && 'btn-active'"
@@ -12,17 +23,42 @@
         </button>
       </div>
     </div>
-    <div class="flex-1 h-full">
-      <div class="text-white flex flex-col h-full w-[11rem] justify-between mx-auto">
-        <GridSettingsItem
-          class="w-full mx-auto"
-          v-for="property in gridProperties"
-          :key="property.name"
-          :property="property"
+    <div class="flex flex-col items-center space-y-6 flex-1 min-h-0">
+      <p class="text-[#9f9f9f]">Färger på nuvarande bräde</p>
+      <div class="h-8 w-full flex items-center px-[1.25rem]">
+        <div class="flex w-full rounded overflow-hidden">
+          <button
+            v-for="([tabName, label], index) in [
+              ['landscapes', 'Landskap'],
+              ['resources', 'Resurser'],
+            ]"
+            :key="label"
+            class="flex-1 bg-black border h-8"
+            :class="[
+              activeTab == tabName
+                ? '!bg-opacity-100 text-[#eeeeee] border-green-500 border hover:!bg-opacity-100'
+                : '!bg-opacity-10 text-[#9f9f9f]',
+              tabName == 'landscapes' ? 'rounded-tl rounded-bl' : 'rounded-tr rounded-br',
+              activeTab == 'landscapes' && index == 1 && 'border-l-0',
+              activeTab == 'resources' && index == 0 && 'border-r-0',
+            ]"
+            @click="e => switchTab(e, tabName)"
+          >
+            <span class="relative inlinbe-block bottom-px">{{ label }}</span>
+          </button>
+        </div>
+      </div>
+      <div
+        class="w-full flex flex-col flex-1 min-h-0 max-h-full overflow-auto items-start"
+      >
+        <LandscapeOrResourceItem
+          v-for="(item, index) in currentDataSet"
+          class="pl-[1.25rem]"
+          :class="index !== 0 && 'mt-3'"
+          :key="item.name"
+          :item="item"
+          :tab="activeTab"
         />
-        <button class="btn rounded-full w-full" @click="resetAdjustments">
-          Återställ
-        </button>
       </div>
     </div>
   </div>
@@ -30,15 +66,18 @@
 
 <script>
 import GridSettingsItem from './GridSettingsItem'
+import LandscapeOrResourceItem from './LandscapeOrResourceItem'
 import { scrollToCenter } from '@/helpers/scroll.js'
 
 export default {
   name: 'BoardAndTiles',
   components: {
     GridSettingsItem,
+    LandscapeOrResourceItem,
   },
   data() {
     return {
+      activeTab: 'landscapes',
       gridProperties: [
         {
           name: 'rowCount',
@@ -85,6 +124,11 @@ export default {
       ],
     }
   },
+  computed: {
+    currentDataSet() {
+      return this.$store.state[this.activeTab].data
+    },
+  },
   methods: {
     toggleResourceValuesVisibility(e) {
       this.$store.commit('toggleVisibility', 'ResourceValues')
@@ -93,6 +137,10 @@ export default {
     resetAdjustments() {
       this.$store.dispatch('resetAdjustments')
       scrollToCenter()
+    },
+    switchTab(e, tabName) {
+      this.activeTab = tabName
+      e.currentTarget.blur()
     },
   },
 }

--- a/src/components/SettingsWindow/LandscapeOrResourceItem.vue
+++ b/src/components/SettingsWindow/LandscapeOrResourceItem.vue
@@ -19,7 +19,7 @@
           @blur="$store.commit('inputBlurred')"
         />
       </div>
-      <div v-if="tab == 'landscapes'" class="grid place-items-center h-full w-8">
+      <div v-if="expandable && tab == 'landscapes'" class="grid place-items-center h-full w-8">
         <svg
           class="transition-all duration-300 select-none cursor-pointer hover:opacity-50 transform"
           :class="expanded ? 'rotate-180 translate-y-px' : '-translate-y-0'"
@@ -81,7 +81,7 @@
       </div>
     </div>
     <div
-      v-if="expanded"
+      v-if="expandable && expanded"
       class="flex flex-col items-stretch space-y-2 p-2 rounded-b"
       :style="{
         backgroundColor: item.color,
@@ -118,8 +118,8 @@
           :key="resource.name + index"
           class="flex justify-between p-2 w-full rounded"
           :style="{
-            backgroundColor: $store.getters.resourceColors[resource.name],
-            color: $store.getters.invertedResourceColors[resource.name],
+            backgroundColor: $store.getters.resourceColors.main[resource.name],
+            color: $store.getters.resourceColors.inverted[resource.name],
           }"
         >
           <span class="inline-block flex-1 font-semibold">{{ resource.name }}</span>
@@ -140,7 +140,7 @@
                       <input
                         class="text-gray-900 font-semibold text-center w-8 bg-transparent"
                         :style="{
-                          color: $store.getters.invertedResourceColors[resource.name],
+                          color: $store.getters.resourceColors.inverted[resource.name],
                         }"
                         type="number"
                         name="min"
@@ -159,7 +159,7 @@
                       <input
                         class="text-gray-900 font-semibold text-center bg-transparent w-8"
                         :style="{
-                          color: $store.getters.invertedResourceColors[resource.name],
+                          color: $store.getters.resourceColors.inverted[resource.name],
                         }"
                         type="number"
                         name="max"
@@ -213,8 +213,8 @@
         </option>
         <option
           :style="{
-            color: $store.getters.invertedResourceColors[resource.name],
-            backgroundColor: $store.getters.resourceColors[resource.name],
+            color: $store.getters.resourceColors.inverted[resource.name],
+            backgroundColor: $store.getters.resourceColors.main[resource.name],
           }"
           v-for="resource of otherAvailableResources"
           :key="resource.name"
@@ -240,7 +240,28 @@ export default {
     StoneIcon,
     WheatIcon,
   },
-  props: ['item', 'tab', 'focusAddedItem', 'removalMode'],
+  props: {
+    item: {
+      type: Object,
+      required: true,
+    },
+    tab: {
+      type: String,
+      required: false,
+    },
+    focusAddedItem: {
+      type: Boolean,
+      default: false,
+    },
+    removalMode: {
+      type: Boolean,
+      default: false,
+    },
+    expandable: {
+      type: Boolean,
+      default: false,
+    },
+  },
   data() {
     return {
       expanded: false,

--- a/src/components/SettingsWindow/LandscapeOrResourceItem.vue
+++ b/src/components/SettingsWindow/LandscapeOrResourceItem.vue
@@ -435,6 +435,9 @@ export default {
         this.itemColor = value
       }, 500)
     },
+    itemColor(value) {
+      this.temporaryItemColor = value
+    }
   },
 }
 </script>

--- a/src/components/SettingsWindow/LandscapesAndResources.vue
+++ b/src/components/SettingsWindow/LandscapesAndResources.vue
@@ -118,6 +118,7 @@
       </div>
     </div>
     <div class="flex flex-col items-center space-y-6 flex-1 min-h-0">
+      <p class="text-[#9f9f9f]">Inställningar för nytt bräde</p>
       <div class="h-8 w-full flex items-center px-[1.25rem]">
         <div class="flex w-full rounded overflow-hidden">
           <button
@@ -128,12 +129,12 @@
             :key="label"
             class="flex-1 bg-black border h-8"
             :class="[
-              tab == tabName
+              activeTab == tabName
                 ? '!bg-opacity-100 text-[#eeeeee] border-green-500 border hover:!bg-opacity-100'
                 : '!bg-opacity-10 text-[#9f9f9f]',
               tabName == 'landscapes' ? 'rounded-tl rounded-bl' : 'rounded-tr rounded-br',
-              tab == 'landscapes' && index == 1 && 'border-l-0',
-              tab == 'resources' && index == 0 && 'border-r-0',
+              activeTab == 'landscapes' && index == 1 && 'border-l-0',
+              activeTab == 'resources' && index == 0 && 'border-r-0',
             ]"
             @click="e => switchTab(e, tabName)"
           >
@@ -156,10 +157,11 @@
             :class="index !== 0 && 'mt-3'"
             :key="item.name"
             :item="item"
-            :tab="tab"
+            :tab="activeTab"
             :focusAddedItem="focusAddedItem"
             @didFocusAddedItem="focusAddedItem = false"
             :removalMode="removalMode"
+            :expandable="true"
           />
         </transition-group>
       </div>
@@ -202,7 +204,7 @@ export default {
   },
   data() {
     return {
-      tab: 'landscapes',
+      activeTab: 'landscapes',
       focusAddedItem: false,
       removalMode: false,
       renderKey: 0,
@@ -210,7 +212,7 @@ export default {
   },
   computed: {
     currentDataSet() {
-      return this.$store.state[this.tab].data
+      return this.$store.state[this.activeTab].data
     },
   },
   methods: {
@@ -219,26 +221,26 @@ export default {
       e.target.blur()
     },
     switchTab(e, tabName) {
-      this.tab = tabName
+      this.activeTab = tabName
       e?.currentTarget.blur()
       this.renderKey++
     },
     addNew(mutation, tabName) {
       this.$store.commit(mutation)
 
-      if (tabName !== this.tab) {
+      if (tabName !== this.activeTab) {
         this.focusAddedItem = true
         this.switchTab(undefined, tabName)
       }
     },
     resetState() {
-      const action = this.tab == 'landscapes' ? 'resetLandscapes' : 'resetResources'
+      const action = this.activeTab == 'landscapes' ? 'resetLandscapes' : 'resetResources'
       this.$store.dispatch(action)
       this.renderKey++
     },
     async removeAll() {
       const action =
-        this.tab == 'landscapes' ? 'removeAllLandscapes' : 'removeAllResources'
+        this.activeTab == 'landscapes' ? 'removeAllLandscapes' : 'removeAllResources'
       this.$store.dispatch(action)
     },
   },

--- a/src/components/SettingsWindow/LandscapesAndResources.vue
+++ b/src/components/SettingsWindow/LandscapesAndResources.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="relative rounded flex h-full items-stretch" id="resource-settings">
     <div class="flex-1">
-      <div class="h-full flex flex-col space-y-3 w-36 mx-auto pt-[3.5rem]">
+      <div class="h-full flex flex-col space-y-3 w-[11rem] mx-auto pt-[3.5rem]">
         <button
-          class="!bg-[#197c4a] text-[#eaffea] !rounded-full flex px-3"
+          class="!bg-[#197c4a] text-[#eaffea] !rounded-full flex px-3 w-full"
           @click="addNew('addLandscape', 'landscapes')"
         >
           <svg
@@ -24,7 +24,7 @@
           </span>
         </button>
         <button
-          class="!bg-[#197c4a] text-[#eaffea] !rounded-full flex px-3"
+          class="!bg-[#197c4a] text-[#eaffea] !rounded-full flex px-3 w-full"
           @click="addNew('addResource', 'resources')"
         >
           <svg
@@ -45,7 +45,7 @@
           </span>
         </button>
         <button
-          class="text-[#eaffea] !rounded-full flex px-3 bg-yellow-600"
+          class="text-[#eaffea] !rounded-full flex px-3 bg-yellow-600 w-full"
           @click="
             e => {
               resetState()
@@ -69,7 +69,7 @@
           <span class="ml-1">Återställ</span>
         </button>
         <button
-          class="text-[#eaffea] !rounded-full flex px-3"
+          class="text-[#eaffea] !rounded-full flex px-3 w-full"
           :class="removalMode ? '!bg-[#369]' : '!bg-[#901312]'"
           @click="
             e => {
@@ -103,23 +103,14 @@
           </span>
         </button>
         <button
-          class="h-8 border rounded  text-sm tracking-wide bg-black !mt-auto"
-          :class="
-            $store.state.preferences.showOverview
-              ? '!border-green-500 text-green-200'
-              : 'border-gray-300 text-gray-300 !bg-opacity-10'
-          "
+          class="btn w-full !mt-auto"
+          :class="$store.state.preferences.showOverview && 'btn-active'"
           @click="e => toggleVisibility(e, 'Overview')"
         >
           {{ $store.state.preferences.showOverview ? 'Visar' : 'Visa' }} översikt
         </button>
         <button
-          class="h-8 border rounded  text-sm tracking-wide bg-black"
-          :class="
-            $store.state.preferences.showSummary
-              ? '!border-green-500 text-green-200'
-              : 'border-gray-300 text-gray-300 !bg-opacity-10'
-          "
+          :class="$store.state.preferences.showSummary ? 'btn w-full btn-active' : 'btn'"
           @click="e => toggleVisibility(e, 'Summary')"
         >
           {{ $store.state.preferences.showSummary ? 'Visar' : 'Visa' }} summering

--- a/src/components/SettingsWindow/NewBoard.vue
+++ b/src/components/SettingsWindow/NewBoard.vue
@@ -102,23 +102,9 @@
             {{ removalMode ? 'Klar' : 'Ta bort...' }}
           </span>
         </button>
-        <button
-          class="btn w-full !mt-auto"
-          :class="$store.state.preferences.showOverview && 'btn-active'"
-          @click="e => toggleVisibility(e, 'Overview')"
-        >
-          {{ $store.state.preferences.showOverview ? 'Visar' : 'Visa' }} översikt
-        </button>
-        <button
-          :class="$store.state.preferences.showSummary ? 'btn w-full btn-active' : 'btn'"
-          @click="e => toggleVisibility(e, 'Summary')"
-        >
-          {{ $store.state.preferences.showSummary ? 'Visar' : 'Visa' }} summering
-        </button>
       </div>
     </div>
     <div class="flex flex-col items-center space-y-6 flex-1 min-h-0">
-      <p class="text-[#9f9f9f]">Inställningar för nytt bräde</p>
       <div class="h-8 w-full flex items-center px-[1.25rem]">
         <div class="flex w-full rounded overflow-hidden">
           <button
@@ -162,6 +148,7 @@
             @didFocusAddedItem="focusAddedItem = false"
             :removalMode="removalMode"
             :expandable="true"
+            @change="submitChange"
           />
         </transition-group>
       </div>
@@ -198,7 +185,7 @@
 import LandscapeOrResourceItem from './LandscapeOrResourceItem'
 
 export default {
-  name: 'LandscapesAndResources',
+  name: 'NewBoard',
   components: {
     LandscapeOrResourceItem,
   },
@@ -216,10 +203,6 @@ export default {
     },
   },
   methods: {
-    toggleVisibility(e, item) {
-      this.$store.commit('toggleVisibility', item)
-      e.target.blur()
-    },
     switchTab(e, tabName) {
       this.activeTab = tabName
       e?.currentTarget.blur()
@@ -242,6 +225,38 @@ export default {
       const action =
         this.activeTab == 'landscapes' ? 'removeAllLandscapes' : 'removeAllResources'
       this.$store.dispatch(action)
+    },
+    submitChange(item, property, value, resource) {
+      let mutation
+      const resourceName = resource?.name
+
+      if (resource) {
+        mutation = 'setResourceValueOnLandscape'
+  
+        if (
+          (property == 'max' && value < resource.min) ||
+          (property == 'min' && value > resource.max)
+        ) {
+          this.$store.commit(mutation, {
+            name: item.name,
+            property: property == 'max' ? 'min' : 'max',
+            value,
+            resourceName,
+          })
+        }
+      } else {
+        mutation =
+          this.activeTab == 'landscapes'
+            ? 'setLandscapeParameter'
+            : 'setResourceParameter'
+      }
+
+      this.$store.commit(mutation, {
+        name: item.name,
+        property,
+        value,
+        ...(resourceName && { resourceName }),
+      })
     },
   },
 }

--- a/src/components/SettingsWindow/Settings.vue
+++ b/src/components/SettingsWindow/Settings.vue
@@ -12,11 +12,17 @@
       >
         Inställningar
       </div>
-      <div class="p-2 space-y-3 border-[10px] border-r-0 border-black flex-1 min-h-0">
+      <div
+        class="p-2 space-y-3 border-[10px] border-r-0 border-black flex-1 min-h-0 flex flex-col"
+      >
         <button class="btn w-full rounded-full" @click="generateNewResourceValues">
           Generera nya resursvärden
         </button>
-        <button class="btn w-full rounded-full" @click="generateNewTiles">
+        <button
+          class="btn w-full rounded-full"
+          :class="activeTab == 'newBoard' && 'highlighted'"
+          @click="generateNewTiles"
+        >
           Generera nytt bräde
         </button>
         <button class="btn w-full rounded-full" @click="saveSettings">
@@ -24,6 +30,27 @@
         </button>
         <button class="btn w-full rounded-full" @click="loadSettings">
           Ladda
+        </button>
+        <button
+          class="btn w-full !mt-auto"
+          :class="$store.state.preferences.showResourceValues && 'btn-active'"
+          @click="e => toggleVisibility(e, 'ResourceValues')"
+        >
+          {{ $store.state.preferences.showResourceValues ? 'Visar' : 'Visa' }}
+          resursvärden
+        </button>
+        <button
+          class="btn w-full"
+          :class="$store.state.preferences.showOverview && 'btn-active'"
+          @click="e => toggleVisibility(e, 'Overview')"
+        >
+          {{ $store.state.preferences.showOverview ? 'Visar' : 'Visa' }} översikt
+        </button>
+        <button
+          :class="$store.state.preferences.showSummary ? 'btn w-full btn-active' : 'btn'"
+          @click="e => toggleVisibility(e, 'Summary')"
+        >
+          {{ $store.state.preferences.showSummary ? 'Visar' : 'Visa' }} summering
         </button>
       </div>
     </div>
@@ -47,16 +74,16 @@
         class="shadow-inner border-black border-[10px] py-8 flex-1"
         :style="{ height: 'calc(100vh - 200px)', maxHeight: '80vh', minWidth: '40rem' }"
       >
-        <LandscapesAndResources v-if="activeTab == 'landscapesAndResources'" />
-        <BoardAndTiles v-if="activeTab == 'boardAndTiles'" />
+        <NewBoard v-show="activeTab == 'newBoard'" />
+        <AdjustBoard v-show="activeTab == 'adjustBoard'" />
       </div>
     </div>
   </div>
 </template>
 
 <script>
-import LandscapesAndResources from './LandscapesAndResources'
-import BoardAndTiles from './BoardAndTiles'
+import NewBoard from './NewBoard'
+import AdjustBoard from './AdjustBoard'
 import vClickOutside from 'v-click-outside'
 import EventBus from '@/eventBus'
 import localForage from 'localforage'
@@ -65,8 +92,8 @@ import { scrollToCenter } from '@/helpers/scroll.js'
 export default {
   name: 'Menu',
   components: {
-    LandscapesAndResources,
-    BoardAndTiles,
+    NewBoard,
+    AdjustBoard,
   },
   directives: {
     clickOutside: vClickOutside.directive,
@@ -75,15 +102,15 @@ export default {
     return {
       tabs: [
         {
-          name: 'landscapesAndResources',
-          label: 'Landskap & Resurser',
+          name: 'newBoard',
+          label: 'Nytt Bräde',
         },
         {
-          name: 'boardAndTiles',
-          label: 'Bräde & Brickor',
+          name: 'adjustBoard',
+          label: 'Justera Bräde',
         },
       ],
-      activeTab: 'landscapesAndResources',
+      activeTab: 'newBoard',
     }
   },
   methods: {
@@ -100,6 +127,10 @@ export default {
     generateNewTiles() {
       this.$store.dispatch('generateNewTiles')
       scrollToCenter()
+    },
+    toggleVisibility(e, item) {
+      this.$store.commit('toggleVisibility', item)
+      e.target.blur()
     },
     async saveSettings() {
       const dialog = await this.$swal({

--- a/src/components/SettingsWindow/Settings.vue
+++ b/src/components/SettingsWindow/Settings.vue
@@ -155,6 +155,18 @@ export default {
     },
     async loadSettings() {
       const savedSettingsMeta = await localForage.getItem('savedSettingsMeta')
+
+      if (!savedSettingsMeta?.length) {
+        await this.$swal({
+          text: 'Inga sparade inställningar att ladda',
+          showCancelButton: false,
+          confirmButtonText: 'OK',
+          allowOutsideClick: true,
+        })
+
+        return
+      }
+
       const inputOptions = Object.assign(
         ...savedSettingsMeta
           .sort((a, b) => a.date - b.date)

--- a/src/components/SettingsWindow/Settings.vue
+++ b/src/components/SettingsWindow/Settings.vue
@@ -2,31 +2,48 @@
   <div
     :class="
       `h-[80vh] rounded overflow-hidden bg-black bg-opacity-95 
-      fixed right-0 mr-12 top-1/2 transform -translate-y-1/2 z-[1100] flex flex-col`
+      fixed right-0 mr-12 top-1/2 transform -translate-y-1/2 z-[1100] flex`
     "
     v-click-outside="onClickOutside"
   >
-    <div class="flex border-b-2 border-black mx-px h-10">
-      <button
-        class="flex-1 hover:bg-black bg-opacity-100 hover:!opacity-100 border-b-2"
-        :class="
-          activeTab == tab.name
-            ? 'border-green-500 text-white'
-            : 'border-transparent text-gray-500 hover:!text-gray-400'
-        "
-        v-for="tab in tabs"
-        :key="tab.name"
-        @click="e => selectTab(e, tab.name)"
+    <div class="h-full flex flex-col">
+      <div
+        class="h-10 w-full flex items-center justify-center text-white text-opacity-30 tracking-wide font-semibold"
       >
-        {{ tab.label }}
-      </button>
+        Inställningar
+      </div>
+      <div class="p-2 space-y-3 border-[10px] border-r-0 border-black flex-1 min-h-0">
+        <button class="btn w-full rounded-full" @click="generateNewResourceValues">
+          Generera nya resursvärden
+        </button>
+        <button class="btn w-full rounded-full" @click="generateNewTiles">
+          Generera nytt bräde
+        </button>
+      </div>
     </div>
-    <div
-      class="shadow-inner border-black border-[10px] py-8 flex-1"
-      :style="{ height: 'calc(100vh - 200px)', maxHeight: '80vh', minWidth: '40rem' }"
-    >
-      <LandscapesAndResources v-if="activeTab == 'landscapesAndResources'" />
-      <BoardAndTiles v-if="activeTab == 'boardAndTiles'" @close="$emit('close')" />
+    <div class="flex flex-col">
+      <div class="flex border-b-2 border-black mx-px h-10">
+        <button
+          class="flex-1 hover:bg-black bg-opacity-100 hover:!opacity-100 border-b-2"
+          :class="
+            activeTab == tab.name
+              ? 'border-green-500 text-white'
+              : 'border-transparent text-gray-500 hover:!text-gray-400'
+          "
+          v-for="tab in tabs"
+          :key="tab.name"
+          @click="e => selectTab(e, tab.name)"
+        >
+          {{ tab.label }}
+        </button>
+      </div>
+      <div
+        class="shadow-inner border-black border-[10px] py-8 flex-1"
+        :style="{ height: 'calc(100vh - 200px)', maxHeight: '80vh', minWidth: '40rem' }"
+      >
+        <LandscapesAndResources v-if="activeTab == 'landscapesAndResources'" />
+        <BoardAndTiles v-if="activeTab == 'boardAndTiles'" />
+      </div>
     </div>
   </div>
 </template>
@@ -58,7 +75,7 @@ export default {
     }
   },
   directives: {
-    clickOutside: vClickOutside.directive
+    clickOutside: vClickOutside.directive,
   },
   methods: {
     selectTab(e, name) {
@@ -67,7 +84,15 @@ export default {
     },
     onClickOutside() {
       this.$emit('close')
-    }
+    },
+    generateNewResourceValues() {
+      EventBus.$emit('reassignResources')
+      this.$emit('close')
+    },
+    generateNewTiles() {
+      this.$store.dispatch('generateNewTiles')
+      scrollToCenter()
+    },
   },
 }
 </script>

--- a/src/main.js
+++ b/src/main.js
@@ -2,13 +2,26 @@ import Vue from 'vue'
 import App from './App.vue'
 import store from './store'
 import vClickOutside from 'v-click-outside'
+import VueSweetalert2 from 'vue-sweetalert2'
+import 'sweetalert2/dist/sweetalert2.min.css'
+
 import './assets/tailwind.css'
 
 Vue.config.productionTip = false
 
+const sweetAlertConfig = {
+  showClass: {
+    popup: 'fade',
+  },
+  customClass: {
+    confirmButton: 'bg-green-500',
+  },
+}
+
 Vue.use(vClickOutside)
+Vue.use(VueSweetalert2, sweetAlertConfig)
 
 new Vue({
   store,
-  render: h => h(App)
+  render: h => h(App),
 }).$mount('#app')

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -5,7 +5,7 @@ import cuid from 'cuid'
 async function performTimeStampCheck(params) {
   const timeStamp = await localForage.getItem('timeStamp')
 
-  if (new Date(timeStamp) < new Date('2021-07-05T18:32:38.785Z')) {
+  if (new Date(timeStamp) < new Date('2021-08-09T18:32:38.785Z')) {
     const grid = localForage.removeItem('grid')
     const landscapes = localForage.removeItem('landscapes')
     const resources = localForage.removeItem('resources')

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -32,12 +32,18 @@ export default {
   async setInitialLandscapes({ commit }, settings) {
     const savedData = (await localForage.getItem('landscapes')) || null
 
-    commit('setLandscapeState', (settings?.landscapes ?? savedData) || storeConfig.initialState.landscapes)
+    commit(
+      'setLandscapeState',
+      (settings?.landscapes ?? savedData) || storeConfig.initialState.landscapes
+    )
   },
   async setInitialResources({ commit }, settings) {
     const savedData = (await localForage.getItem('resources')) || null
 
-    commit('setResourceState', (settings?.resources ?? savedData) || storeConfig.initialState.resources)
+    commit(
+      'setResourceState',
+      (settings?.resources ?? savedData) || storeConfig.initialState.resources
+    )
   },
   async setInitialBoard({ commit }, settings) {
     const savedData = (await localForage.getItem('board')) || {}
@@ -50,15 +56,23 @@ export default {
         tileRowsStash: savedData.tileRowsStash || [],
         selectedTiles: savedData.selectedTiles || [],
         draggableItems: savedData.draggableItems || [],
+        colors: savedData.colors || {},
+        landscapesAndResources: savedData.landscapesAndResources || [],
       }
     }
 
-    commit('setBoardState', (settings?.board ?? tileData) || storeConfig.initialState.board)
+    commit(
+      'setBoardState',
+      (settings?.board ?? tileData) || storeConfig.initialState.board
+    )
   },
   async setInitialPreferences({ commit }, settings) {
     const savedData = (await localForage.getItem('preferences')) || null
 
-    commit('setPreferencesState', (settings?.preferences ?? savedData) || storeConfig.initialState.preferences)
+    commit(
+      'setPreferencesState',
+      (settings?.preferences ?? savedData) || storeConfig.initialState.preferences
+    )
   },
   async setApplicationState({ dispatch }, settings = null) {
     performTimeStampCheck()
@@ -105,5 +119,5 @@ export default {
     const savedSettings = await localForage.getItem(`savedSettings:${id}`)
 
     dispatch('setApplicationState', savedSettings)
-  }
+  },
 }

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -5,7 +5,7 @@ import cuid from 'cuid'
 async function performTimeStampCheck(params) {
   const timeStamp = await localForage.getItem('timeStamp')
 
-  if (new Date(timeStamp) < new Date('2021-06-19T18:18:56.926Z')) {
+  if (new Date(timeStamp) < new Date('2021-07-05T18:32:38.785Z')) {
     const grid = localForage.removeItem('grid')
     const landscapes = localForage.removeItem('landscapes')
     const resources = localForage.removeItem('resources')

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,5 +1,6 @@
 import localForage from 'localforage'
 import { storeConfig } from '@/store'
+import cuid from 'cuid'
 
 async function performTimeStampCheck(params) {
   const timeStamp = await localForage.getItem('timeStamp')
@@ -17,7 +18,7 @@ async function performTimeStampCheck(params) {
 }
 
 export default {
-  async setInitialGrid({ commit }) {
+  async setInitialGrid({ commit }, settings) {
     const savedData = (await localForage.getItem('grid')) || {}
 
     let gridData = {}
@@ -26,19 +27,19 @@ export default {
       gridData[key] = savedData[key] || value
     })
 
-    commit('setGridState', gridData || storeConfig.initialState.grid)
+    commit('setGridState', (settings?.grid ?? gridData) || storeConfig.initialState.grid)
   },
-  async setInitialLandscapes({ commit }) {
+  async setInitialLandscapes({ commit }, settings) {
     const savedData = (await localForage.getItem('landscapes')) || null
 
-    commit('setLandscapeState', savedData || storeConfig.initialState.landscapes)
+    commit('setLandscapeState', (settings?.landscapes ?? savedData) || storeConfig.initialState.landscapes)
   },
-  async setInitialResources({ commit }) {
+  async setInitialResources({ commit }, settings) {
     const savedData = (await localForage.getItem('resources')) || null
 
-    commit('setResourceState', savedData || storeConfig.initialState.resources)
+    commit('setResourceState', (settings?.resources ?? savedData) || storeConfig.initialState.resources)
   },
-  async setInitialBoard({ commit }) {
+  async setInitialBoard({ commit }, settings) {
     const savedData = (await localForage.getItem('board')) || {}
 
     let tileData
@@ -52,24 +53,24 @@ export default {
       }
     }
 
-    commit('setBoardState', tileData || storeConfig.initialState.board)
+    commit('setBoardState', (settings?.board ?? tileData) || storeConfig.initialState.board)
   },
-  async setInitialPreferences({ commit }) {
+  async setInitialPreferences({ commit }, settings) {
     const savedData = (await localForage.getItem('preferences')) || null
 
-    commit('setPreferencesState', savedData || storeConfig.initialState)
+    commit('setPreferencesState', (settings?.preferences ?? savedData) || storeConfig.initialState.preferences)
   },
-  async setInitialState({ dispatch }) {
+  async setApplicationState({ dispatch }, settings = null) {
     performTimeStampCheck()
 
-    await dispatch('setInitialResources')
+    await dispatch('setInitialResources', settings)
 
     const promises = [
       'setInitialGrid',
       'setInitialLandscapes',
       'setInitialBoard',
       'setInitialPreferences',
-    ].map(action => dispatch(action))
+    ].map(action => dispatch(action, settings))
 
     await Promise.all(promises)
 
@@ -83,4 +84,26 @@ export default {
     localForage.setItem('board', state.board)
     localForage.setItem('timeStamp', new Date())
   },
+  async saveSettings({ state }, name) {
+    const id = cuid()
+    const settings = Object.assign(
+      ...Object.entries(state)
+        .filter(([k, v]) => !Object.keys(storeConfig.initialState.root).includes(k))
+        .map(([k, v]) => ({ [k]: v }))
+    )
+
+    const newMetaEntry = { id, name, date: new Date() }
+    const allMetaEntries = [newMetaEntry]
+    const savedSettingsMeta = await localForage.getItem('savedSettingsMeta')
+
+    if (savedSettingsMeta?.length) allMetaEntries.push(...savedSettingsMeta)
+
+    localForage.setItem(`savedSettings:${id}`, settings)
+    localForage.setItem('savedSettingsMeta', allMetaEntries)
+  },
+  async loadSettings({ dispatch }, id) {
+    const savedSettings = await localForage.getItem(`savedSettings:${id}`)
+
+    dispatch('setApplicationState', savedSettings)
+  }
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,9 +4,11 @@ import { StoreConfig } from './storeConfig'
 
 Vue.use(Vuex)
 
-export const storeConfig = new StoreConfig()
+const storeConfiguration = new StoreConfig()
 
-const store = new Vuex.Store(storeConfig.create())
+export const storeConfig = JSON.parse(JSON.stringify(storeConfiguration))
+
+const store = new Vuex.Store(storeConfiguration.create())
 
 let updateLocalStorageTimer = undefined
 

--- a/src/store/modules/board.js
+++ b/src/store/modules/board.js
@@ -131,10 +131,12 @@ export default {
         ? {
             main: Object.assign(...landscapes.map(l => ({ [l.name]: l.color }))),
             inverted: Object.assign(
-              ...landscapes.map(l => ({ [l.name]: l.invertedColor }))
+              ...landscapes.map(l => ({ [l.name]: getInvertedHexColor(l.color) }))
             ),
             grayscale: Object.assign(
-              ...landscapes.map(l => ({ [l.name]: l.invertedColorGrayscale }))
+              ...landscapes.map(l => ({
+                [l.name]: getInvertedHexcolorGrayscale(l.color),
+              }))
             ),
           }
         : {}

--- a/src/store/modules/board.js
+++ b/src/store/modules/board.js
@@ -2,6 +2,7 @@ import EventBus from '@/eventBus'
 import cuid from 'cuid'
 import {
   getRandomHexColor,
+  getInvertedHexColor,
   getInvertedHexcolorGrayscale,
 } from '../../helpers/getDynamicColor'
 
@@ -11,12 +12,19 @@ export default {
     tileRowsStash: [],
     selectedTiles: [],
     draggableItems: [],
+    colors: {},
+    landscapesAndResources: [],
   }),
   mutations: {
     setBoardState(state, payload) {
       Object.keys(payload).forEach(property => {
         state.hasOwnProperty(property) && (state[property] = payload[property])
       })
+    },
+    setBoardColor(state, { dataset, itemName, color }) {
+      state.colors[dataset].main[itemName] = color
+      state.colors[dataset].inverted[itemName] = getInvertedHexColor(color)
+      state.colors[dataset].grayscale[itemName] = getInvertedHexcolorGrayscale(color)
     },
     addTileRow(state, { row }) {
       state.tileRows.push(row)
@@ -115,7 +123,44 @@ export default {
       })
       dispatch('arrangeLandscapePool')
 
-      EventBus.$emit('buildGrid')
+      EventBus.$emit('buildNewBoard')
+    },
+    setBoardColors({ state, rootState, commit }) {
+      const landscapes = rootState.landscapes.data
+      const landscapeColors = landscapes.length
+        ? {
+            main: Object.assign(...landscapes.map(l => ({ [l.name]: l.color }))),
+            inverted: Object.assign(
+              ...landscapes.map(l => ({ [l.name]: l.invertedColor }))
+            ),
+            grayscale: Object.assign(
+              ...landscapes.map(l => ({ [l.name]: l.invertedColorGrayscale }))
+            ),
+          }
+        : {}
+
+      const resources = rootState.resources.data
+      const resourceColors = resources.length
+        ? {
+            main: Object.assign(...resources.map(r => ({ [r.name]: r.color }))),
+            inverted: Object.assign(
+              ...resources.map(r => ({ [r.name]: r.invertedColor }))
+            ),
+            grayscale: Object.assign(
+              ...resources.map(r => ({ [r.name]: r.invertedColorGrayscale }))
+            ),
+          }
+        : {}
+
+      const colors = { landscapes: landscapeColors, resources: resourceColors }
+
+      commit('setBoardState', { ...state, colors })
+    },
+    setBoardLandscapes({ state, rootState, commit }) {
+      const landscapesAndResources =
+        JSON.parse(JSON.stringify(rootState.landscapes.data)) || []
+
+      commit('setBoardState', { ...state, landscapesAndResources })
     },
   },
 }

--- a/src/store/modules/landscapes.js
+++ b/src/store/modules/landscapes.js
@@ -11,6 +11,7 @@ export default {
         fraction: 0,
         color: '#efefef',
         invertedColor: '#0f0f0f',
+        invertedColorGrayscale: '#0f0f0f',
         resources: [
           {
             name: '',
@@ -31,7 +32,17 @@ export default {
       return fractions.reduce((a, b) => a + b, 0)
     },
     landscapeColors(state) {
-      return Object.assign(...state.data.map(l => ({ [l.name]: l.color })))
+      if (state.data.length) {
+        return {
+          main: Object.assign(...state.data.map(l => ({ [l.name]: l.color }))),
+          inverted: Object.assign(
+            ...state.data.map(l => ({ [l.name]: l.invertedColor }))
+          ),
+          grayscale: Object.assign(
+            ...state.data.map(l => ({ [l.name]: l.invertedColorGrayscale }))
+          ),
+        }
+      } else return {}
     },
   },
   mutations: {
@@ -59,6 +70,7 @@ export default {
         fraction: 1,
         color,
         invertedColor: getInvertedHexColor(color),
+        invertedColorGrayscale: getInvertedHexcolorGrayscale(color),
         resources: [],
       }
 

--- a/src/store/modules/landscapes.js
+++ b/src/store/modules/landscapes.js
@@ -1,48 +1,21 @@
 import Vue from 'vue'
-import { getRandomHexColor, getInvertedHexColor } from '@/helpers/getDynamicColor.js'
+import {
+  getRandomHexColor,
+  getInvertedHexColor,
+  getInvertedHexcolorGrayscale,
+} from '@/helpers/getDynamicColor.js'
 import { getUniqueDefaultName } from '@/helpers/getUniqueName.js'
 import { storeConfig } from '@/store'
 
 export default {
   state: () => ({
-    data: [
-      {
-        name: '',
-        fraction: 0,
-        color: '#efefef',
-        invertedColor: '#0f0f0f',
-        invertedColorGrayscale: '#0f0f0f',
-        resources: [
-          {
-            name: '',
-            min: 0,
-            max: 0,
-          },
-        ],
-      },
-    ],
+    data: [],
     landscapePool: [],
   }),
   getters: {
-    landscapeDistributions(state, getters) {
-      return state.data.map(l => l.fraction)
-    },
     landscapeDistributionSum(state) {
       const fractions = state.data.map(l => l.fraction)
       return fractions.reduce((a, b) => a + b, 0)
-    },
-    landscapeColors(state) {
-      if (state.data.length) {
-        return {
-          main: Object.assign(...state.data.map(l => ({ [l.name]: l.color }))),
-          inverted: Object.assign(
-            ...state.data.map(l => ({ [l.name]: l.invertedColor }))
-          ),
-          grayscale: Object.assign(
-            ...state.data.map(l => ({ [l.name]: l.invertedColorGrayscale }))
-          ),
-        }
-      } else return {}
     },
   },
   mutations: {

--- a/src/store/modules/resources.js
+++ b/src/store/modules/resources.js
@@ -9,29 +9,8 @@ import { storeConfig } from '@/store'
 
 export default {
   state: () => ({
-    data: [
-      {
-        name: '',
-        color: '#efefef',
-        icon: '',
-      },
-    ],
+    data: [],
   }),
-  getters: {
-    resourceColors(state) {
-      if (state.data.length) {
-        return {
-          main: Object.assign(...state.data.map(r => ({ [r.name]: r.color }))),
-          inverted: Object.assign(
-            ...state.data.map(r => ({ [r.name]: r.invertedColor }))
-          ),
-          grayscale: Object.assign(
-            ...state.data.map(r => ({ [r.name]: r.invertedColorGrayscale }))
-          ),
-        }
-      } else return {}
-    },
-  },
   mutations: {
     setResourceState(state, payload) {
       Object.keys(payload).forEach(property => {

--- a/src/store/modules/resources.js
+++ b/src/store/modules/resources.js
@@ -1,5 +1,9 @@
 import Vue from 'vue'
-import { getRandomHexColor, getInvertedHexColor } from '@/helpers/getDynamicColor.js'
+import {
+  getRandomHexColor,
+  getInvertedHexColor,
+  getInvertedHexcolorGrayscale,
+} from '@/helpers/getDynamicColor.js'
 import { getUniqueDefaultName } from '@/helpers/getUniqueName.js'
 import { storeConfig } from '@/store'
 
@@ -16,13 +20,16 @@ export default {
   getters: {
     resourceColors(state) {
       if (state.data.length) {
-        return Object.assign(...state.data.map(r => ({ [r.name]: r.color })))
-      } else return []
-    },
-    invertedResourceColors(state) {
-      if (state.data.length) {
-        return Object.assign(...state.data.map(r => ({ [r.name]: r.invertedColor })))
-      } else return []
+        return {
+          main: Object.assign(...state.data.map(r => ({ [r.name]: r.color }))),
+          inverted: Object.assign(
+            ...state.data.map(r => ({ [r.name]: r.invertedColor }))
+          ),
+          grayscale: Object.assign(
+            ...state.data.map(r => ({ [r.name]: r.invertedColorGrayscale }))
+          ),
+        }
+      } else return {}
     },
   },
   mutations: {
@@ -45,6 +52,7 @@ export default {
         name,
         color,
         invertedColor: getInvertedHexColor(color),
+        invertedColorGrayscale: getInvertedHexcolorGrayscale(color),
       }
 
       state.data.push(payload)

--- a/src/store/storeConfig.js
+++ b/src/store/storeConfig.js
@@ -15,7 +15,7 @@ const initialState = {
     hasFocusedInput: false,
     draggableIsBeingDragged: false,
     draggableIsOnDropzone: false,
-  },
+  },  
   board: {
     tileRows: [],
     tileRowsStash: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1172,6 +1172,11 @@
   resolved "https://registry.yarnpkg.com/@soda/get-current-script/-/get-current-script-1.0.2.tgz#a53515db25d8038374381b73af20bb4f2e508d87"
   integrity sha512-T7VNNlYVM1SgQ+VsMYhnDkcGmWhQdL0bDyGm5TlQ3GBXnJscEClUUOKduWTmm2zCnvNLC1hc3JpuXjs/nFOc5w==
 
+"@sweetalert2/theme-bulma@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@sweetalert2/theme-bulma/-/theme-bulma-5.0.1.tgz#8b685816987a01044c4e813e405091c650a8d29c"
+  integrity sha512-sCWUG5ku7645W/t+SAJ9kgM8iWnVQIFEPa2o4tq4SXyt5SqKY3E9Wz+fCJLq3Ypyqvgmmv9/XWNngHCfHuREjQ==
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
@@ -9253,6 +9258,11 @@ svgo@^1.0.0, svgo@^1.3.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
+sweetalert2@11.x:
+  version "11.0.18"
+  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-11.0.18.tgz#9547859cc1a79815d5d02a6e0d1a3d44da3f8dc1"
+  integrity sha512-sF6huRQqqRGz7p9F8XFKSICl5hOiXjjpmnwAO8vlyJKAyMNZb2fvdok11JIGQjqcqVMIag/VLNWF4eEsIKQKGw==
+
 symbol-tree@^3.2.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -9893,6 +9903,13 @@ vue-svg-loader@^0.16.0:
   dependencies:
     loader-utils "^1.2.3"
     svg-to-vue "^0.7.0"
+
+vue-sweetalert2@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/vue-sweetalert2/-/vue-sweetalert2-5.0.2.tgz#b34f21f551aaefb88d94991daf7528913f66cefe"
+  integrity sha512-28pcpmvaFxwoXIUkOWwhZhmsV749jXxha8JicwPoSKyFKR5FhIaZU6UHO5WlUCLIVUI6sAWY6WngK2x/iXYwZg==
+  dependencies:
+    sweetalert2 "11.x"
 
 vue-template-compiler@^2.6.12:
   version "2.6.12"


### PR DESCRIPTION
## Changes
**Features**
* Add ability to save and load the current state of the board and presets
* Add ability to change colors of tiles on board, separately from colors for new board

**Minor**
* Restructure settings menus
* Fix behaviour of some input fields (were mutation props directly)

**Packages added**
*  [sweet-alert 2](https://sweetalert.js.org/docs/) for dialogs and alerts